### PR TITLE
Improve when buffer have different length

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,11 @@ module.exports = function xor (a, b) {
   var max = Math.max(a.length, b.length)
   var buffer = Buffer.allocUnsafe(max)
 
-  for (var i = 0; i <= min; ++i) {
+  for (var i = 0; i < min; ++i) {
     buffer[i] = a[i] ^ b[i]
   }
 
-  ((a.length > b.length) ? a : b).copy(buffer, min, max)
+  ((a.length > b.length) ? a : b).copy(buffer, min, min, max)
 
   return buffer
 }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 var Buffer = require('safe-buffer').Buffer
 
 module.exports = function xor (a, b) {
-  var length = Math.max(a.length, b.length)
-  var buffer = Buffer.allocUnsafe(length)
+  var min = Math.min(a.length, b.length)
+  var max = Math.max(a.length, b.length)
+  var buffer = Buffer.allocUnsafe(max)
 
-  for (var i = 0; i < length; ++i) {
+  for (var i = 0; i <= min; ++i) {
     buffer[i] = a[i] ^ b[i]
   }
+
+  ((a.length > b.length) ? a : b).copy(buffer, min, max)
 
   return buffer
 }


### PR DESCRIPTION
I have measure execution time following this code
```javascript
var xor = require('buffer-xor')

var a = new Buffer.from('a'.repeat(100000))
var c = new Buffer.from('f'.repeat(100000))
var b = new Buffer.from('a'.repeat(1000))

var start = microtime.now()
xor(a, c)
console.log('Time:',  microtime.now() - start)
```
Result
```
[Old XOR] Same length: 30965
[New XOR] Same length: 18486
[Old XOR] Different length: 20902
[New XOR] different length: 15390
Reverse...
[New XOR] different length: 17363
[Old XOR] Different length: 22312
[New XOR] Same length: 16772
[Old XOR] Same length: 16437
```