### PR TITLE
Added power support for the travis.yml file with ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 sudo: false
 os: linux
 language: node_js
+arch:
+   - amd64
+   - ppc64le
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
+  - "10"
+  - "11"
+  - "12"
   - "iojs"
   - "4"
   - "5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
   - "12"
   - "iojs"
   - "4"
-  - "5"
+  - "14"
 env:
   matrix:
     - TEST_SUITE=unit


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing